### PR TITLE
Fix issue 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
         <exec.maven.plugin.version>1.2</exec.maven.plugin.version>
         <slf4j.version>1.7.5</slf4j.version>
-        <jackson2.version>2.2.3</jackson2.version>
+        <jackson2.version>2.5.4</jackson2.version>
         <opencsv.version>2.4</opencsv.version>
         <metrics3.version>3.0.1</metrics3.version>
         <commons.logging.version>1.1.1</commons.logging.version>


### PR DESCRIPTION
I fix [this](https://github.com/awslabs/dynamodb-titan-storage-backend/issues/17#issuecomment-157859453).

> ObjectMapper.enable method used there requires Jackson 2.5+. I fixed this by editing the pom file for this.
