### PR TITLE
Create run-local-dynamodb-titan.sh

### DIFF
--- a/run-local-dynamodb-titan.sh
+++ b/run-local-dynamodb-titan.sh
@@ -1,0 +1,7 @@
+mvn install
+echo 'compiled dynamodb-titan-storage-backend using maven'
+mvn test -Pstart-dynamodb-local &
+echo 'started dyanmodb local'
+cd server/dynamodb-titan100-storage-backend-1.0.0-hadoop1
+bin/gremlin-server.sh ${PWD}/conf/gremlin-server/gremlin-server-local.yaml &
+echo 'started gremlin server'


### PR DESCRIPTION
For the convenience of developers, this .sh should be added to ease the run of the local server.
