### PR TITLE
Nullpointer exception when parsing endpoint for a local instance of DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ includes Gremlin Server.
 6. Change directories to the Gremlin Server home.
 
     ```
-    cd server/dynamodb-titan100-storage-backend-1.0.0-hadoop1
+    cd server/dynamodb-titan100-storage-backend-1.0.3-hadoop1
     ```
 7. Start Gremlin Server with the DynamoDB Local configuration.
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
             <name>Justin Panian</name>
             <email>panianj@amazon.com</email>
         </contributor>
+        <contributor>
+            <name>Johan Jacobs</name>
+            <email>johanjcbs@gmail.com</email>
+            <url>https://www.linkedin.com/in/johanjcbs/</url>
+        </contributor>
     </contributors>
     <inceptionYear>2014</inceptionYear>
     <licenses>

--- a/src/main/java/com/amazon/titan/diskstorage/dynamodb/DynamoDBDelegate.java
+++ b/src/main/java/com/amazon/titan/diskstorage/dynamodb/DynamoDBDelegate.java
@@ -44,6 +44,7 @@ import com.amazon.titan.diskstorage.dynamodb.ExponentialBackoff.Scan;
 import com.amazon.titan.diskstorage.dynamodb.iterator.ParallelScanner;
 import com.amazon.titan.diskstorage.dynamodb.iterator.ScanSegmentWorker;
 import com.amazon.titan.diskstorage.dynamodb.mutation.MutateWorker;
+import com.amazonaws.util.StringUtils;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
@@ -175,9 +176,10 @@ public class DynamoDBDelegate
         }
         if(endpoint != null && !endpoint.isEmpty()) {
             Region region = null;
-            try {
-                region = Region.getRegion(Regions.fromName(AwsHostNameUtils.parseRegion(endpoint, "dynamodb")));
-            } catch(IllegalArgumentException e) {
+            String parsedEndpoint = AwsHostNameUtils.parseRegion(endpoint, "dynamodb");
+            if(!StringUtils.isNullOrEmpty(parsedEndpoint)) {
+                region = Region.getRegion(Regions.fromName(parsedEndpoint));
+            } else {
                 region = Region.getRegion(Regions.US_EAST_2); //for use with DynamoDB Local, any signing region will do
             }
             Preconditions.checkState(region != null);


### PR DESCRIPTION
When connecting to a local instance of DynamoDB, the AwsHostNameUtil.parseRegion returns null, since the endpoint is not a valid AWS endpoint. This null is then passed down to Regions.fromName and then an NPE is thrown and thus preventing the DynamoDBDelegate class from being instantiated. 