### PR TITLE
Add heartbeat to test methods so that Travis CI does not abort latent tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ script:
 notifications:
   email:
     - amcp@amazon.co.jp
-    - johan@nichestreem.com
+    - johanjcbs@gmail.com

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/amazon/titan/TestCiHeartbeat.java
+++ b/src/test/java/com/amazon/titan/TestCiHeartbeat.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.titan;
+
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.apache.log4j.Appender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ *
+ * @author Johan Jacobs
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TestCiHeartbeat {
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Mock
+    private Appender mockAppender;
+    @Captor
+    private ArgumentCaptor<LoggingEvent> captorLoggingEvent;
+
+    @Before
+    public void setup() {
+
+        Logger root = Logger.getRootLogger();
+        root.addAppender(mockAppender);
+        root.setLevel(Level.WARN);
+    }
+
+    @Test
+    public void testHeartbeatConsoleOutput() throws InterruptedException {
+
+        CiHeartbeat ciHeartbeat = new CiHeartbeat(500, 3);
+
+        ciHeartbeat.startHeartbeat(testName.getMethodName());
+
+        Thread.sleep(2000);
+
+        ciHeartbeat.stopHeartbeat();
+
+        verify(mockAppender, times(6)).doAppend(captorLoggingEvent.capture());
+
+        LoggingEvent unitTestStartEvent = captorLoggingEvent.getAllValues().get(0);
+        Assert.assertEquals("Heartbeat - [started] - testHeartbeatConsoleOutput - 0ms", unitTestStartEvent.getMessage());
+
+        LoggingEvent heartbeatOneEvent = captorLoggingEvent.getAllValues().get(1);
+        Assert.assertTrue(heartbeatOneEvent.getMessage().toString().contains("Heartbeat - [1] - testHeartbeatConsoleOutput - "));
+
+        LoggingEvent heartbeatTwoEvent = captorLoggingEvent.getAllValues().get(2);
+        Assert.assertTrue(heartbeatTwoEvent.getMessage().toString().contains("Heartbeat - [2] - testHeartbeatConsoleOutput - "));
+
+        LoggingEvent heartbeatThreeEvent = captorLoggingEvent.getAllValues().get(3);
+        Assert.assertTrue(heartbeatThreeEvent.getMessage().toString().contains("Heartbeat - [3] - testHeartbeatConsoleOutput - "));
+
+        LoggingEvent heartbeatfourEvent = captorLoggingEvent.getAllValues().get(4);
+        Assert.assertTrue(heartbeatfourEvent.getMessage().toString().contains("Heartbeat - [4] - testHeartbeatConsoleOutput - "));
+
+        LoggingEvent unitTestEndEvent = captorLoggingEvent.getAllValues().get(5);
+        Assert.assertTrue(unitTestEndEvent.getMessage().toString().contains("Heartbeat - [finished] - testHeartbeatConsoleOutput - "));
+    }
+}

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBIDAuthorityTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBIDAuthorityTest.java
@@ -16,6 +16,7 @@ package com.amazon.titan.diskstorage.dynamodb;
 
 import java.util.Collections;
 
+import com.amazon.titan.testutils.CiHeartbeat;
 import org.junit.After;
 
 import com.amazon.titan.TestGraphUtil;
@@ -25,19 +26,29 @@ import com.thinkaurelius.titan.diskstorage.configuration.BasicConfiguration;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBIDAuthorityTest extends IDAuthorityTest {
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
 
     protected final BackendDataModel model;
     protected AbstractDynamoDBIDAuthorityTest(WriteConfiguration baseConfig,
             BackendDataModel model) {
         super(TestGraphUtil.instance().appendStoreConfig(model, baseConfig.copy(), Collections.singletonList("ids")));
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
     
     @Override
@@ -47,8 +58,14 @@ public abstract class AbstractDynamoDBIDAuthorityTest extends IDAuthorityTest {
         return new DynamoDBStoreManager(config);
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
     @After
-    public void cleanUpTables() throws Exception {
+    public void tearDownTest() throws Exception {
         TestGraphUtil.instance().cleanUpTables();
+        this.ciHeartbeat.stopHeartbeat();
     }
 }

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBLockStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBLockStoreTest.java
@@ -19,7 +19,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.amazon.titan.testutils.CiHeartbeat;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 
 import com.amazon.titan.TestGraphUtil;
@@ -29,20 +31,28 @@ import com.thinkaurelius.titan.diskstorage.configuration.BasicConfiguration;
 import com.thinkaurelius.titan.diskstorage.configuration.ModifiableConfiguration;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBLockStoreTest extends LockKeyColumnValueStoreTest {
 
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     private String concreteClassName;
     protected AbstractDynamoDBLockStoreTest(BackendDataModel model) {
         //TODO(amcp) make this protected in super
         this.concreteClassName = getClass().getSimpleName();
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -69,9 +79,15 @@ public abstract class AbstractDynamoDBLockStoreTest extends LockKeyColumnValueSt
         return new DynamoDBStoreManager(config);
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
     @After
-    public void cleanUpTables() throws Exception {
+    public void tearDownTest() throws Exception {
         TestGraphUtil.instance().cleanUpTables();
+        this.ciHeartbeat.stopHeartbeat();
     }
 
     @Ignore

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBLogTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBLogTest.java
@@ -60,10 +60,11 @@ import com.thinkaurelius.titan.diskstorage.util.StaticArrayBuffer;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBLogTest {
 
     protected final BackendDataModel model;
@@ -117,7 +118,7 @@ public abstract class AbstractDynamoDBLogTest {
     @Before
     //END FROM LogTest
     //BEGIN FROM KCVSLogTest
-    public void setup() throws Exception {
+    public void setupTest() throws Exception {
         StoreManager m = openStorageManager();
         m.clearStorage();
         m.close();
@@ -131,7 +132,7 @@ public abstract class AbstractDynamoDBLogTest {
 
     @After
     //END FROM LogTest
-    public void shutdown() throws Exception {
+    public void shutdownTest() throws Exception {
         //BEGIN FROM KCVSLogTest
         close();
         //END FROM KCVSLogTest

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBMultiWriteStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBMultiWriteStoreTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import com.amazon.titan.testutils.CiHeartbeat;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -60,19 +61,27 @@ import com.thinkaurelius.titan.diskstorage.keycolumnvalue.cache.NoKCVSCache;
 import com.thinkaurelius.titan.diskstorage.util.StaticArrayBuffer;
 import com.thinkaurelius.titan.diskstorage.util.StaticArrayEntry;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBMultiWriteStoreTest extends AbstractKCVSTest {
+
+    @Rule
+    public final TestName testName = new TestName();
 
     public static final String TEST_STORE1 = "testStore1";
     public static final String TEST_STORE2 = "testStore2";
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBMultiWriteStoreTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
@@ -113,16 +122,19 @@ public abstract class AbstractDynamoDBMultiWriteStoreTest extends AbstractKCVSTe
     private Random rand = new Random(10);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUpTest() throws Exception {
         StoreManager m = openStorageManager();
         m.clearStorage();
         m.close();
         open();
+
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDownTest() throws Exception {
         close();
+        this.ciHeartbeat.stopHeartbeat();
     }
 
     public void open() throws BackendException {

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/AbstractDynamoDBStoreTest.java
@@ -26,8 +26,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import com.thinkaurelius.titan.testutil.RandomGenerator;
+import com.amazon.titan.testutils.CiHeartbeat;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.Before;
+import org.junit.Rule;
 
 import com.amazon.titan.TestGraphUtil;
 import com.google.common.collect.ImmutableList;
@@ -42,19 +45,26 @@ import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.diskstorage.keycolumnvalue.KeyColumnValueStore;
 import com.thinkaurelius.titan.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
-import com.thinkaurelius.titan.testutil.RandomGenerator;
+import org.junit.rules.TestName;
+
 
 /**
  *
  * @author Alexander Patrikalakis
+ * @author Johan Jacobs
  *
  */
 public abstract class AbstractDynamoDBStoreTest extends KeyColumnValueStoreTest
 {
+    @Rule
+    public final TestName testName = new TestName();
+
     private final int NUM_COLUMNS = 50;
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBStoreTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
     @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException
@@ -197,8 +207,16 @@ public abstract class AbstractDynamoDBStoreTest extends KeyColumnValueStoreTest
     }
     //end code from https://github.com/thinkaurelius/titan/blob/1.0.0/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyColumnValueStoreTest.java#L807
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+
+    }
+    //end code from https://github.com/thinkaurelius/titan/blob/1.0.0/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyColumnValueStoreTest.java#L807
+
     @After
-    public void cleanUpTables() throws Exception {
+    public void tearDownTest() throws Exception {
         TestGraphUtil.instance().cleanUpTables();
+        this.ciHeartbeat.stopHeartbeat();
     }
 }

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/MultiDynamoDBIDAuthorityTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/MultiDynamoDBIDAuthorityTest.java
@@ -14,6 +14,7 @@
  */
 package com.amazon.titan.diskstorage.dynamodb;
 
+import com.amazon.titan.testcategory.MultiIdAuthorityLogLockStoreCategory;
 import org.junit.experimental.categories.Category;
 
 import com.amazon.titan.testcategory.MultiIdAuthorityLogLockStoreCategory;

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/MultiDynamoDBMultiWriteStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/MultiDynamoDBMultiWriteStoreTest.java
@@ -19,6 +19,7 @@ import com.amazon.titan.testcategory.MultipleItemTestCategory;
 
 import org.junit.experimental.categories.Category;
 
+
 /**
 *
 * @author Alexander Patrikalakis

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/MultiDynamoDBStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/MultiDynamoDBStoreTest.java
@@ -22,6 +22,7 @@ import org.junit.experimental.categories.Category;
 
 import com.amazon.titan.testcategory.IsolateMultiConcurrentGetSlice;
 import com.amazon.titan.testcategory.IsolateMultiConcurrentGetSliceAndMutate;
+
 import com.amazon.titan.testcategory.MultiDynamoDBStoreTestCategory;
 import com.amazon.titan.testcategory.MultipleItemTestCategory;
 import com.thinkaurelius.titan.diskstorage.BackendException;

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/SingleDynamoDBMultiWriteStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/SingleDynamoDBMultiWriteStoreTest.java
@@ -31,5 +31,4 @@ public class SingleDynamoDBMultiWriteStoreTest extends AbstractDynamoDBMultiWrit
     public SingleDynamoDBMultiWriteStoreTest() {
         super(BackendDataModel.SINGLE);
     }
-
 }

--- a/src/test/java/com/amazon/titan/diskstorage/dynamodb/SingleDynamoDBStoreTest.java
+++ b/src/test/java/com/amazon/titan/diskstorage/dynamodb/SingleDynamoDBStoreTest.java
@@ -26,6 +26,7 @@ import com.amazon.titan.testcategory.SingleDynamoDBStoreTestCategory;
 import com.amazon.titan.testcategory.SingleItemTestCategory;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 
+
 /**
  *
  * @author Alexander Patrikalakis
@@ -33,6 +34,7 @@ import com.thinkaurelius.titan.diskstorage.BackendException;
  */
 public class SingleDynamoDBStoreTest extends AbstractDynamoDBStoreTest
 {
+
     public SingleDynamoDBStoreTest()
     {
         super(BackendDataModel.SINGLE);

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBEventualGraphTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBEventualGraphTest.java
@@ -14,6 +14,8 @@
  */
 package com.amazon.titan.graphdb.dynamodb;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -21,17 +23,26 @@ import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.graphdb.TitanEventualGraphTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBEventualGraphTest extends TitanEventualGraphTest {
 
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBEventualGraphTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -45,4 +56,13 @@ public abstract class AbstractDynamoDBEventualGraphTest extends TitanEventualGra
         TestGraphUtil.instance().cleanUpTables();
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
+    }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphConcurrentTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphConcurrentTest.java
@@ -23,8 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.AfterClass;
-import org.junit.Test;
+import com.amazon.titan.testutils.CiHeartbeat;
 
 import com.amazon.titan.TestGraphUtil;
 import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
@@ -33,17 +32,26 @@ import com.thinkaurelius.titan.core.TitanVertex;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.graphdb.TitanGraphConcurrentTest;
+import org.junit.*;
+import org.junit.rules.TestName;
 
 /**
  *
  * @author Alexander Patrikalakis
+ * @author Johan Jacobs
  *
  */
 public abstract class AbstractDynamoDBGraphConcurrentTest extends TitanGraphConcurrentTest
 {
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBGraphConcurrentTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -55,6 +63,16 @@ public abstract class AbstractDynamoDBGraphConcurrentTest extends TitanGraphConc
     @AfterClass
     public static void deleteTables() throws BackendException {
         TestGraphUtil.instance().cleanUpTables();
+    }
+
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
     }
 
     //begin titan-test code - modified because test takes too long, kept number of runnables

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphIterativeTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphIterativeTest.java
@@ -14,6 +14,8 @@
  */
 package com.amazon.titan.graphdb.dynamodb;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -25,17 +27,26 @@ import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
 import com.thinkaurelius.titan.graphdb.TitanGraphIterativeBenchmark;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-* TODO, seems like all the Tests are commented out in the superclass
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ * TODO, seems like all the Tests are commented out in the superclass
+ */
 public abstract class AbstractDynamoDBGraphIterativeTest extends TitanGraphIterativeBenchmark {
 
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBGraphIterativeTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -58,4 +69,13 @@ public abstract class AbstractDynamoDBGraphIterativeTest extends TitanGraphItera
         TestGraphUtil.instance().cleanUpTables();
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
+    }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphPerformanceMemoryTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphPerformanceMemoryTest.java
@@ -14,6 +14,8 @@
  */
 package com.amazon.titan.graphdb.dynamodb;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -21,17 +23,26 @@ import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.graphdb.TitanGraphPerformanceMemoryTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
  *
  * @author Alexander Patrikalakis
+ * @author Johan Jacobs
  *
  */
 public abstract class AbstractDynamoDBGraphPerformanceMemoryTest extends TitanGraphPerformanceMemoryTest
 {
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBGraphPerformanceMemoryTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -43,5 +54,15 @@ public abstract class AbstractDynamoDBGraphPerformanceMemoryTest extends TitanGr
     @AfterClass
     public static void deleteTables() throws BackendException {
         TestGraphUtil.instance().cleanUpTables();
+    }
+
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
     }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphSpeedTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphSpeedTest.java
@@ -14,6 +14,8 @@
  */
 package com.amazon.titan.graphdb.dynamodb;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -24,13 +26,22 @@ import com.thinkaurelius.titan.graphdb.SpeedTestSchema;
 import com.thinkaurelius.titan.graphdb.TitanGraphSpeedTest;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.graphdb.database.StandardTitanGraph;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBGraphSpeedTest extends TitanGraphSpeedTest {
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     private static StandardTitanGraph graph;
     private static SpeedTestSchema schema;
     protected final BackendDataModel model;
@@ -38,6 +49,7 @@ public abstract class AbstractDynamoDBGraphSpeedTest extends TitanGraphSpeedTest
     protected AbstractDynamoDBGraphSpeedTest(BackendDataModel model) throws BackendException {
         super(TestGraphUtil.instance().graphConfig(model));
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @AfterClass
@@ -64,4 +76,13 @@ public abstract class AbstractDynamoDBGraphSpeedTest extends TitanGraphSpeedTest
         return schema;
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
+    }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBGraphTest.java
@@ -18,7 +18,10 @@ package com.amazon.titan.graphdb.dynamodb;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
@@ -34,10 +37,15 @@ import com.thinkaurelius.titan.graphdb.TitanGraphTest;
  * the DynamoDB storage backend.
  *
  * @author Alexander Patrikalakis
+ * @author Johan Jacobs
  *
  */
 public abstract class AbstractDynamoDBGraphTest extends TitanGraphTest {
-    @Rule public TestName name = new TestName();
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
 
     @Override
     protected boolean isLockingOptimistic() {
@@ -47,11 +55,12 @@ public abstract class AbstractDynamoDBGraphTest extends TitanGraphTest {
     protected final BackendDataModel model;
     protected AbstractDynamoDBGraphTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
     public WriteConfiguration getConfiguration() {
-        final String methodName = name.getMethodName();
+        final String methodName = testName.getMethodName();
         final List<String> extraStoreNames = methodName.contains("simpleLogTest") ? Collections.singletonList("ulog_test") : Collections.<String>emptyList();
         return TestGraphUtil.instance().graphConfigWithClusterPartitionsAndExtraStores(model, extraStoreNames, 1 /*titanClusterPartitions*/);
     }
@@ -59,5 +68,15 @@ public abstract class AbstractDynamoDBGraphTest extends TitanGraphTest {
     @AfterClass
     public static void deleteTables() throws BackendException {
         TestGraphUtil.instance().cleanUpTables();
+    }
+
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
     }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBOLAPTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBOLAPTest.java
@@ -15,10 +15,13 @@
 package com.amazon.titan.graphdb.dynamodb;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -26,12 +29,20 @@ import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.olap.OLAPTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 public abstract class AbstractDynamoDBOLAPTest extends OLAPTest {
 
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBOLAPTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -45,4 +56,13 @@ public abstract class AbstractDynamoDBOLAPTest extends OLAPTest {
         TestGraphUtil.instance().cleanUpTables();
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
+    }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBOperationCountingTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBOperationCountingTest.java
@@ -14,6 +14,8 @@
  */
 package com.amazon.titan.graphdb.dynamodb;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -21,17 +23,26 @@ import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.graphdb.TitanOperationCountingTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
-*
-* @author Alexander Patrikalakis
-*
-*/
+ *
+ * @author Alexander Patrikalakis
+ * @author Johan Jacobs
+ *
+ */
 public abstract class AbstractDynamoDBOperationCountingTest extends TitanOperationCountingTest {
 
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBOperationCountingTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -48,5 +59,15 @@ public abstract class AbstractDynamoDBOperationCountingTest extends TitanOperati
     @Override
     public boolean storeUsesConsistentKeyLocker() {
         return false;//TODO(amcp) remove abstract and make super do return !features.hasLocking()
+    }
+
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
     }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBPartitionGraphTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/AbstractDynamoDBPartitionGraphTest.java
@@ -16,6 +16,8 @@ package com.amazon.titan.graphdb.dynamodb;
 
 import java.util.Collections;
 
+import com.amazon.titan.testutils.CiHeartbeat;
+import org.junit.After;
 import org.junit.AfterClass;
 
 import com.amazon.titan.TestGraphUtil;
@@ -23,17 +25,27 @@ import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.graphdb.TitanPartitionGraphTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
  *
  * @author Alexander Patrikalakis
+ * @author Johan Jacobs
  *
  */
 public abstract class AbstractDynamoDBPartitionGraphTest extends TitanPartitionGraphTest
 {
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private final CiHeartbeat ciHeartbeat;
     protected final BackendDataModel model;
     protected AbstractDynamoDBPartitionGraphTest(BackendDataModel model) {
         this.model = model;
+        this.ciHeartbeat = new CiHeartbeat();
     }
 
     @Override
@@ -46,5 +58,15 @@ public abstract class AbstractDynamoDBPartitionGraphTest extends TitanPartitionG
     @AfterClass
     public static void deleteTables() throws BackendException {
         TestGraphUtil.instance().cleanUpTables();
+    }
+
+    @Before
+    public void setUpTest() throws Exception {
+        this.ciHeartbeat.startHeartbeat(this.testName.getMethodName());
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        this.ciHeartbeat.stopHeartbeat();
     }
 }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/MultiDynamoDBGraphTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/MultiDynamoDBGraphTest.java
@@ -27,10 +27,12 @@ import com.amazon.titan.testcategory.MultiDynamoDBGraphTestCategory;
 import com.amazon.titan.testcategory.MultipleItemTestCategory;
 import com.thinkaurelius.titan.diskstorage.BackendException;
 
+
 /**
  * @author Alexander Patrikalakis
  */
 public class MultiDynamoDBGraphTest extends AbstractDynamoDBGraphTest {
+
     public MultiDynamoDBGraphTest() {
         super(BackendDataModel.MULTI);
     }

--- a/src/test/java/com/amazon/titan/graphdb/dynamodb/SingleDynamoDBGraphTest.java
+++ b/src/test/java/com/amazon/titan/graphdb/dynamodb/SingleDynamoDBGraphTest.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import com.amazon.titan.testcategory.SingleItemTestCategory;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import org.junit.experimental.categories.Category;
 import com.amazon.titan.diskstorage.dynamodb.BackendDataModel;
 import com.amazon.titan.testcategory.SingleDynamoDBGraphTestCategory;
 import com.amazon.titan.testcategory.SingleItemTestCategory;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.thinkaurelius.titan.core.EdgeLabel;
@@ -67,7 +69,7 @@ public class SingleDynamoDBGraphTest extends AbstractDynamoDBGraphTest {
     @Override
     public WriteConfiguration getConfiguration() {
         final WriteConfiguration wc = super.getConfiguration();
-        final String methodName = name.getMethodName();
+        final String methodName = testName.getMethodName();
         if(methodName.contains("testEdgesExceedCacheSize")) {
             //default: 20000, testEdgesExceedCacheSize fails at 16461, passes at 16460
             //this is the maximum number of edges supported for a vertex with no vertex partitioning.

--- a/src/test/java/com/amazon/titan/testutils/CiHeartbeat.java
+++ b/src/test/java/com/amazon/titan/testutils/CiHeartbeat.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.titan.testutils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This heartbeat timer will print to the console every x configured milliseconds. This is to prevent Travis CI from
+ * terminating the build if there is no console output in a 10min time frame. The heartbeat will only run for up to x
+ * configured intervals, this is needed for tests which are really in a hung state and Travis CI can then fail the build.
+ *
+ * The heartbeat is started and stopped before and after each test case. The current running unit test and the current
+ * execution time of the test is included in the heartbeat for better visibility in to any long running tests.
+ *
+ * @author Johan Jacobs
+ *
+ */
+public class CiHeartbeat {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CiHeartbeat.class);
+
+    private static final long DEFAULT_HEARTBEAT_INTERVAL    = 300000;
+    private static final int DEFAULT_MAXIMUM_INTERVALS      = 8;
+
+    private Timer heartbeatTimer;
+    private boolean timerStarted;
+    private final long configuredHeartbeatInterval;
+    private final int configuredMaximumIntervals;
+    private String configuredUnitTestName;
+    private final long heartbeatStartTime;
+
+    public CiHeartbeat() {
+        this(DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_MAXIMUM_INTERVALS);
+    }
+
+    public CiHeartbeat(long heartbeatInterval, int maximumIntervals) {
+
+        this.configuredHeartbeatInterval = heartbeatInterval;
+        this.configuredMaximumIntervals = maximumIntervals;
+        this.heartbeatStartTime = System.currentTimeMillis();
+    }
+
+    public void startHeartbeat(String unitTestName) {
+
+        if(this.timerStarted) {
+            LOG.warn(String.format("Travis CI heartbeat timer is already running for unit test with name: %s.", this.configuredUnitTestName));
+            return;
+        }
+
+        this.configuredUnitTestName = unitTestName;
+        this.heartbeatTimer = new Timer("Unit test heartbeat timer");
+
+        HeartbeatTimerTask heartbeatTimerTask = new HeartbeatTimerTask(this.configuredMaximumIntervals, this.heartbeatStartTime, this.configuredUnitTestName);
+        this.heartbeatTimer.schedule(heartbeatTimerTask, this.configuredHeartbeatInterval, this.configuredHeartbeatInterval);
+
+        this.timerStarted = true;
+
+        LOG.info(String.format("Heartbeat - [started] - %s - 0ms",
+                this.configuredUnitTestName));
+    }
+
+    public void stopHeartbeat() {
+
+        if (this.heartbeatTimer != null && this.timerStarted) {
+            this.heartbeatTimer.cancel();
+            this.heartbeatTimer = null;
+            this.timerStarted = false;
+
+            long currentRunTimeMilliseconds = System.currentTimeMillis() - heartbeatStartTime;
+
+            LOG.info(String.format("Heartbeat - [finished] - %s - %dms",
+                    configuredUnitTestName,
+                    currentRunTimeMilliseconds));
+        }
+    }
+}

--- a/src/test/java/com/amazon/titan/testutils/HeartbeatTimerTask.java
+++ b/src/test/java/com/amazon/titan/testutils/HeartbeatTimerTask.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.titan.testutils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.TimerTask;
+
+/**
+ *
+ * @author Johan Jacobs
+ *
+ */
+public class HeartbeatTimerTask extends TimerTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatTimerTask.class);
+
+    private int intervals;
+    private final int configuredMaximumIntervals;
+    private final long heartbeatStartTime;
+    private final String configuredUnitTestName;
+
+    public HeartbeatTimerTask(int configuredMaximumIntervals, long heartbeatStartTime, String configuredUnitTestName) {
+        this.configuredMaximumIntervals = configuredMaximumIntervals;
+        this.heartbeatStartTime = heartbeatStartTime;
+        this.configuredUnitTestName = configuredUnitTestName;
+    }
+
+    @Override
+    public void run() {
+
+        intervals++;
+        long currentRunTimeMilliseconds = System.currentTimeMillis() - heartbeatStartTime;
+
+        if (intervals == configuredMaximumIntervals) {
+            LOG.warn(String.format("Heartbeat - [%d] - %s - %dms.",
+                    intervals,
+                    configuredUnitTestName,
+                    currentRunTimeMilliseconds));
+            return;
+        }
+
+        LOG.info(String.format("Heartbeat - [%d] - %s - %dms",
+                intervals,
+                configuredUnitTestName,
+                currentRunTimeMilliseconds));
+    }
+}

--- a/src/test/resources/dynamodb-local.properties
+++ b/src/test/resources/dynamodb-local.properties
@@ -6,7 +6,7 @@ storage.buffer-size=1024
 metrics.enabled=true
 #metrics.prefix=t
 # Required; specify logging interval in milliseconds
-metrics.console.interval=480000
+#metrics.console.interval=480000
 #metrics.csv.interval=500
 #metrics.csv.directory=metrics
 # Turn off titan retries as we batch and have our own exponential backoff strategy.

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,6 @@
 log4j.rootLogger=info, stdout
 #log4j.logger.com.amazon.titan=trace
+log4j.logger.com.amazon.titan.testutils=INFO
 log4j.logger.com.thinkaurelius=ERROR
 log4j.category.org.elasticsearch=ERROR
 log4j.logger.com.amazonaws=ERROR


### PR DESCRIPTION
Introduced a heartbeat message to the console output during unit tests and disabled the metrics put to the console from Titan.

Reference: https://github.com/awslabs/dynamodb-titan-storage-backend/issues/87