### PR TITLE
Added IsolateGraphFailingTestCategory to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ env:
     - MODULE="SingleMultiWriteStoreTestCategory" CATEGORY="SingleDynamoDBMultiWriteStoreTestCategory"
   #2.8 minutes
     - MODULE="MultiMultiWriteStoreTestCategory" CATEGORY="MultiDynamoDBMultiWriteStoreTestCategory"
+  #To be added
+    - MODULE="IsolateGraphFailing" CATEGORY="IsolateGraphFailingTestCategory"
 addons:
   apt:
     packages:


### PR DESCRIPTION
Added IsolateGraphFailingTestCategory to the build matrix

**Reference:** https://github.com/awslabs/dynamodb-titan-storage-backend/issues/113