### PR TITLE
Refactored IsolateGraphFailingTestCategory name to GraphSimpleLogTestCategory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
   #2.8 minutes
     - MODULE="MultiMultiWriteStoreTestCategory" CATEGORY="MultiDynamoDBMultiWriteStoreTestCategory"
   #To be added
-    - MODULE="IsolateGraphFailing" CATEGORY="IsolateGraphFailingTestCategory"
+    - MODULE="GraphSimpleLogTest" CATEGORY="GraphSimpleLogTestCategory"
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -410,8 +410,6 @@ fail on Travis CI.
     ```bash
     mvn verify -P integration-tests -Dinclude.category="**/*.java" \
         -Dgroups=com.amazon.janusgraph.testcategory.IsolateRemainingTestsCategory > o 2>&1
-    mvn verify -P integration-tests -Dinclude.category="**/*.java" \
-    -Dgroups=com.amazon.janusgraph.testcategory.IsolateGraphFailingTestCategory > o 2>&1
     ```
 6. Exit the screen with `CTRL-A D` and logout of the EC2 instance.
 7. Monitor the CPU usage of your EC2 instance in the EC2 console. The single-item tests

--- a/src/test/java/com/amazon/janusgraph/graphdb/dynamodb/MultiDynamoDBGraphTest.java
+++ b/src/test/java/com/amazon/janusgraph/graphdb/dynamodb/MultiDynamoDBGraphTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import com.amazon.janusgraph.diskstorage.dynamodb.BackendDataModel;
-import com.amazon.janusgraph.testcategory.IsolateGraphFailingTestCategory;
+import com.amazon.janusgraph.testcategory.GraphSimpleLogTestCategory;
 import com.amazon.janusgraph.testcategory.IsolateMultiEdgesExceedCacheSize;
 import com.amazon.janusgraph.testcategory.IsolateMultiLargeJointIndexRetrieval;
 import com.amazon.janusgraph.testcategory.IsolateMultiVertexCentricQuery;
@@ -81,7 +81,7 @@ public class MultiDynamoDBGraphTest extends AbstractDynamoDBGraphTest {
 
     @Test
     @Override
-    @Category({IsolateGraphFailingTestCategory.class, MultipleItemTestCategory.class })
+    @Category({GraphSimpleLogTestCategory.class, MultipleItemTestCategory.class })
     public void simpleLogTest() throws InterruptedException {
         super.simpleLogTest();
     }
@@ -235,7 +235,7 @@ public class MultiDynamoDBGraphTest extends AbstractDynamoDBGraphTest {
 
     @Test
     @Override
-    @Category({IsolateGraphFailingTestCategory.class, MultipleItemTestCategory.class })
+    @Category({GraphSimpleLogTestCategory.class, MultipleItemTestCategory.class })
     public void simpleLogTestWithFailure() throws InterruptedException {
         super.simpleLogTestWithFailure();
     }

--- a/src/test/java/com/amazon/janusgraph/graphdb/dynamodb/SingleDynamoDBGraphTest.java
+++ b/src/test/java/com/amazon/janusgraph/graphdb/dynamodb/SingleDynamoDBGraphTest.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import com.amazon.janusgraph.diskstorage.dynamodb.BackendDataModel;
-import com.amazon.janusgraph.testcategory.IsolateGraphFailingTestCategory;
+import com.amazon.janusgraph.testcategory.GraphSimpleLogTestCategory;
 import com.amazon.janusgraph.testcategory.SingleDynamoDBGraphTestCategory;
 import com.amazon.janusgraph.testcategory.SingleItemTestCategory;
 import com.google.common.collect.ImmutableList;
@@ -446,7 +446,7 @@ public class SingleDynamoDBGraphTest extends AbstractDynamoDBGraphTest {
 
     @Test
     @Override
-    @Category({IsolateGraphFailingTestCategory.class, SingleItemTestCategory.class })
+    @Category({GraphSimpleLogTestCategory.class, SingleItemTestCategory.class })
     public void simpleLogTest() throws InterruptedException {
         super.simpleLogTest();
     }
@@ -593,7 +593,7 @@ public class SingleDynamoDBGraphTest extends AbstractDynamoDBGraphTest {
 
     @Test
     @Override
-    @Category({IsolateGraphFailingTestCategory.class, SingleItemTestCategory.class })
+    @Category({GraphSimpleLogTestCategory.class, SingleItemTestCategory.class })
     public void simpleLogTestWithFailure() throws InterruptedException {
         super.simpleLogTestWithFailure();
     }

--- a/src/test/java/com/amazon/janusgraph/testcategory/GraphSimpleLogTestCategory.java
+++ b/src/test/java/com/amazon/janusgraph/testcategory/GraphSimpleLogTestCategory.java
@@ -19,5 +19,5 @@ package com.amazon.janusgraph.testcategory;
  * @author Alexander Patrikalakis
  *
  */
-public interface IsolateGraphFailingTestCategory {
+public interface GraphSimpleLogTestCategory {
 }


### PR DESCRIPTION
Reference: https://github.com/awslabs/dynamodb-titan-storage-backend/issues/113