### PR TITLE
Remove log4j dependency and update the relevant UT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,17 +139,21 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- Gremlin -->
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-core</artifactId>
             <version>${tinkerpop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -173,13 +177,6 @@
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${aws.java.sdk.version}</version>
         </dependency>
-        <!--TODO remove log4j if possible-->
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
@@ -200,6 +197,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/test/java/com/amazon/janusgraph/TestCiHeartbeat.java
+++ b/src/test/java/com/amazon/janusgraph/TestCiHeartbeat.java
@@ -15,79 +15,58 @@
 
 package com.amazon.janusgraph;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import org.apache.log4j.Appender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggingEvent;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.amazon.janusgraph.testutils.HeartbeatTimerTask;
+import com.amazon.janusgraph.testutils.LoggerTestUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.amazon.janusgraph.testutils.CiHeartbeat;
 
 /**
- *
- * @author Johan Jacobs
+ * Refer to https://www.baeldung.com/logback
+ * @author Minghui Tang
  *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class TestCiHeartbeat {
-
     @Rule
     public final TestName testName = new TestName();
 
-    @Mock
-    private Appender mockAppender;
-    @Captor
-    private ArgumentCaptor<LoggingEvent> captorLoggingEvent;
+    private ListAppender<ILoggingEvent> ciHeartbeatListAppender;
+    private ListAppender<ILoggingEvent> heartbeatTimerListAppender;
+    private CiHeartbeat ciHeartbeat;
 
     @Before
     public void setup() {
+        ciHeartbeatListAppender = LoggerTestUtil.getListAppenderForClass(CiHeartbeat.class);
+        heartbeatTimerListAppender = LoggerTestUtil.getListAppenderForClass(HeartbeatTimerTask.class);
 
-        final Logger root = Logger.getRootLogger();
-        root.addAppender(mockAppender);
-        root.setLevel(Level.WARN);
+        ciHeartbeat = new CiHeartbeat(500, 3);
     }
 
     @Test
-    public void testHeartbeatConsoleOutput() throws InterruptedException {
+    public void testHeartbeatConsoleOutput() throws InterruptedException{
+        // given
 
-        final CiHeartbeat ciHeartbeat = new CiHeartbeat(500, 3);
-
+        // when
         ciHeartbeat.startHeartbeat(testName.getMethodName());
 
         Thread.sleep(2000);
 
         ciHeartbeat.stopHeartbeat();
 
-        verify(mockAppender, times(6)).doAppend(captorLoggingEvent.capture());
-
-        final LoggingEvent unitTestStartEvent = captorLoggingEvent.getAllValues().get(0);
-        Assert.assertEquals("Heartbeat - [started] - testHeartbeatConsoleOutput - 0ms", unitTestStartEvent.getMessage());
-
-        final LoggingEvent heartbeatOneEvent = captorLoggingEvent.getAllValues().get(1);
-        Assert.assertTrue(heartbeatOneEvent.getMessage().toString().contains("Heartbeat - [1] - testHeartbeatConsoleOutput - "));
-
-        final LoggingEvent heartbeatTwoEvent = captorLoggingEvent.getAllValues().get(2);
-        Assert.assertTrue(heartbeatTwoEvent.getMessage().toString().contains("Heartbeat - [2] - testHeartbeatConsoleOutput - "));
-
-        final LoggingEvent heartbeatThreeEvent = captorLoggingEvent.getAllValues().get(3);
-        Assert.assertTrue(heartbeatThreeEvent.getMessage().toString().contains("Heartbeat - [3] - testHeartbeatConsoleOutput - "));
-
-        final LoggingEvent heartbeatfourEvent = captorLoggingEvent.getAllValues().get(4);
-        Assert.assertTrue(heartbeatfourEvent.getMessage().toString().contains("Heartbeat - [4] - testHeartbeatConsoleOutput - "));
-
-        final LoggingEvent unitTestEndEvent = captorLoggingEvent.getAllValues().get(5);
-        Assert.assertTrue(unitTestEndEvent.getMessage().toString().contains("Heartbeat - [finished] - testHeartbeatConsoleOutput - "));
+        // then
+        Assert.assertEquals(ciHeartbeatListAppender.list.get(0).getFormattedMessage(), "Heartbeat - [started] - testHeartbeatConsoleOutput - 0ms");
+        Assert.assertTrue(heartbeatTimerListAppender.list.get(0).getMessage().contains("Heartbeat - [1] - testHeartbeatConsoleOutput - "));
+        Assert.assertTrue(heartbeatTimerListAppender.list.get(1).getMessage().contains("Heartbeat - [2] - testHeartbeatConsoleOutput - "));
+        Assert.assertTrue(heartbeatTimerListAppender.list.get(2).getMessage().contains("Heartbeat - [3] - testHeartbeatConsoleOutput - "));
+        Assert.assertTrue(ciHeartbeatListAppender.list.get(1).getMessage().contains( "Heartbeat - [finished] - testHeartbeatConsoleOutput - "));
     }
 }

--- a/src/test/java/com/amazon/janusgraph/testutils/LoggerTestUtil.java
+++ b/src/test/java/com/amazon/janusgraph/testutils/LoggerTestUtil.java
@@ -1,0 +1,19 @@
+package com.amazon.janusgraph.testutils;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
+public class LoggerTestUtil {
+    public static ListAppender<ILoggingEvent> getListAppenderForClass(Class clazz) {
+        Logger logger = (Logger) LoggerFactory.getLogger(clazz);
+
+        ListAppender<ILoggingEvent> loggingEventListAppender = new ListAppender<>();
+        loggingEventListAppender.start();
+
+        logger.addAppender(loggingEventListAppender);
+
+        return loggingEventListAppender;
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### Changes
* remove log4j 1.x dependency
* add `logback` dependency in order to test the slf4j logger (exclude the usage from overlapping dependencies)
* update the old `TestCiHearbeat` UT to a new one. Together with the configuration for test appender and test util class.

### Test result
```
/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home/bin/java -ea -Didea.test.cyclic.buffer.size=26214400 "-javaagent:/Applications/IntelliJ IDEA CE.app/Contents/lib/idea_rt.jar=54342:/Applications/IntelliJ IDEA CE.app/Contents/bin" -Dfile.encoding=UTF-8 -classpath "/Applications/IntelliJ IDEA CE.app/Contents/lib/idea_rt.jar:/Applications/IntelliJ IDEA CE.app/Contents/plugins/junit/lib/junit-rt.jar:/Applications/IntelliJ IDEA CE.app/Contents/plugins/junit/lib/junit5-rt.jar:/Users/tangming/Documents/dynamodb-janusgraph-storage-backend/target/test-classes:/Users/tangming/Documents/dynamodb-janusgraph-storage-backend/target/classes:/Users/tangming/.m2/repository/com/amazonaws/aws-java-sdk-dynamodb/1.11.336/aws-java-sdk-dynamodb-1.11.336.jar:/Users/tangming/.m2/repository/com/amazonaws/aws-java-sdk-s3/1.11.336/aws-java-sdk-s3-1.11.336.jar:/Users/tangming/.m2/repository/com/amazonaws/aws-java-sdk-kms/1.11.336/aws-java-sdk-kms-1.11.336.jar:/Users/tangming/.m2/repository/com/amazonaws/jmespath-java/1.11.336/jmespath-java-1.11.336.jar:/Users/tangming/.m2/repository/org/janusgraph/janusgraph-core/0.2.0/janusgraph-core-0.2.0.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-groovy/3.2.6/gremlin-groovy-3.2.6.jar:/Users/tangming/.m2/repository/org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy/2.4.11/groovy-2.4.11-indy.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-groovysh/2.4.11/groovy-groovysh-2.4.11-indy.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-console/2.4.11/groovy-console-2.4.11.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-templates/2.4.11/groovy-templates-2.4.11.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-xml/2.4.11/groovy-xml-2.4.11.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-swing/2.4.11/groovy-swing-2.4.11.jar:/Users/tangming/.m2/repository/jline/jline/2.12/jline-2.12.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy/2.4.11/groovy-2.4.11.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-json/2.4.11/groovy-json-2.4.11-indy.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-jsr223/2.4.11/groovy-jsr223-2.4.11-indy.jar:/Users/tangming/.m2/repository/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar:/Users/tangming/.m2/repository/com/github/ben-manes/caffeine/caffeine/2.3.1/caffeine-2.3.1.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/tinkergraph-gremlin/3.2.6/tinkergraph-gremlin-3.2.6.jar:/Users/tangming/.m2/repository/org/glassfish/javax.json/1.0/javax.json-1.0.jar:/Users/tangming/.m2/repository/com/codahale/metrics/metrics-ganglia/3.0.1/metrics-ganglia-3.0.1.jar:/Users/tangming/.m2/repository/info/ganglia/gmetric4j/gmetric4j/1.0.3/gmetric4j-1.0.3.jar:/Users/tangming/.m2/repository/com/codahale/metrics/metrics-graphite/3.0.1/metrics-graphite-3.0.1.jar:/Users/tangming/.m2/repository/org/reflections/reflections/0.9.9-RC1/reflections-0.9.9-RC1.jar:/Users/tangming/.m2/repository/org/javassist/javassist/3.16.1-GA/javassist-3.16.1-GA.jar:/Users/tangming/.m2/repository/org/locationtech/spatial4j/spatial4j/0.6/spatial4j-0.6.jar:/Users/tangming/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/tangming/.m2/repository/commons-io/commons-io/2.3/commons-io-2.3.jar:/Users/tangming/.m2/repository/com/carrotsearch/hppc/0.7.1/hppc-0.7.1.jar:/Users/tangming/.m2/repository/com/github/stephenc/high-scale-lib/high-scale-lib/1.1.4/high-scale-lib-1.1.4.jar:/Users/tangming/.m2/repository/org/noggit/noggit/0.6/noggit-0.6.jar:/Users/tangming/.m2/repository/org/apache/commons/commons-text/1.0/commons-text-1.0.jar:/Users/tangming/.m2/repository/org/janusgraph/janusgraph-test/0.2.0/janusgraph-test-0.2.0.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-test/3.2.6/gremlin-test-3.2.6.jar:/Users/tangming/.m2/repository/com/h2database/h2/1.3.171/h2-1.3.171.jar:/Users/tangming/.m2/repository/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-driver/3.2.6/gremlin-driver-3.2.6.jar:/Users/tangming/.m2/repository/io/netty/netty-all/4.0.50.Final/netty-all-4.0.50.Final.jar:/Users/tangming/.m2/repository/org/codehaus/groovy/groovy-sql/2.4.11/groovy-sql-2.4.11-indy.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-server/3.2.6/gremlin-server-3.2.6.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-groovy-test/3.2.6/gremlin-groovy-test-3.2.6.jar:/Users/tangming/.m2/repository/org/apache/commons/commons-math/2.2/commons-math-2.2.jar:/Users/tangming/.m2/repository/com/vividsolutions/jts/1.13/jts-1.13.jar:/Users/tangming/.m2/repository/com/carrotsearch/junit-benchmarks/0.7.0/junit-benchmarks-0.7.0.jar:/Users/tangming/.m2/repository/com/carrotsearch/randomizedtesting/randomizedtesting-runner/2.0.8/randomizedtesting-runner-2.0.8.jar:/Users/tangming/.m2/repository/org/easymock/easymock/3.4/easymock-3.4.jar:/Users/tangming/.m2/repository/org/objenesis/objenesis/2.2/objenesis-2.2.jar:/Users/tangming/.m2/repository/com/codahale/metrics/metrics-core/3.0.1/metrics-core-3.0.1.jar:/Users/tangming/.m2/repository/com/opencsv/opencsv/3.8/opencsv-3.8.jar:/Users/tangming/.m2/repository/commons-beanutils/commons-beanutils/1.9.2/commons-beanutils-1.9.2.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-core/3.2.6/gremlin-core-3.2.6.jar:/Users/tangming/.m2/repository/org/apache/tinkerpop/gremlin-shaded/3.2.6/gremlin-shaded-3.2.6.jar:/Users/tangming/.m2/repository/org/yaml/snakeyaml/1.15/snakeyaml-1.15.jar:/Users/tangming/.m2/repository/org/javatuples/javatuples/1.2/javatuples-1.2.jar:/Users/tangming/.m2/repository/com/jcabi/jcabi-manifests/1.1/jcabi-manifests-1.1.jar:/Users/tangming/.m2/repository/com/jcabi/jcabi-log/0.14/jcabi-log-0.14.jar:/Users/tangming/.m2/repository/com/squareup/javapoet/1.8.0/javapoet-1.8.0.jar:/Users/tangming/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21.jar:/Users/tangming/.m2/repository/junit/junit/4.12/junit-4.12.jar:/Users/tangming/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar:/Users/tangming/.m2/repository/commons-codec/commons-codec/1.7/commons-codec-1.7.jar:/Users/tangming/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/tangming/.m2/repository/com/amazonaws/aws-java-sdk-core/1.11.336/aws-java-sdk-core-1.11.336.jar:/Users/tangming/.m2/repository/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar:/Users/tangming/.m2/repository/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar:/Users/tangming/.m2/repository/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar:/Users/tangming/.m2/repository/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar:/Users/tangming/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.10.2/jackson-databind-2.10.2.jar:/Users/tangming/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.10.2/jackson-annotations-2.10.2.jar:/Users/tangming/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.10.2/jackson-core-2.10.2.jar:/Users/tangming/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.10.2/jackson-dataformat-cbor-2.10.2.jar:/Users/tangming/.m2/repository/joda-time/joda-time/2.8.1/joda-time-2.8.1.jar:/Users/tangming/.m2/repository/commons-configuration/commons-configuration/1.10/commons-configuration-1.10.jar:/Users/tangming/.m2/repository/org/apache/commons/commons-lang3/3.3.1/commons-lang3-3.3.1.jar:/Users/tangming/.m2/repository/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12.jar:/Users/tangming/.m2/repository/com/google/guava/guava/29.0-jre/guava-29.0-jre.jar:/Users/tangming/.m2/repository/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar:/Users/tangming/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/Users/tangming/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/Users/tangming/.m2/repository/org/checkerframework/checker-qual/2.11.1/checker-qual-2.11.1.jar:/Users/tangming/.m2/repository/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar:/Users/tangming/.m2/repository/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar:/Users/tangming/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar:/Users/tangming/.m2/repository/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar:/Users/tangming/.m2/repository/org/mockito/mockito-all/1.8.5/mockito-all-1.8.5.jar:/Users/tangming/.m2/repository/org/mockito/mockito-core/1.8.5/mockito-core-1.8.5.jar:/Users/tangming/.m2/repository/org/projectlombok/lombok/1.18.2/lombok-1.18.2.jar:/Users/tangming/.m2/repository/com/google/code/findbugs/findbugs/3.0.1/findbugs-3.0.1.jar:/Users/tangming/.m2/repository/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar:/Users/tangming/.m2/repository/com/google/code/findbugs/bcel-findbugs/6.0/bcel-findbugs-6.0.jar:/Users/tangming/.m2/repository/com/google/code/findbugs/jFormatString/2.0.1/jFormatString-2.0.1.jar:/Users/tangming/.m2/repository/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar:/Users/tangming/.m2/repository/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar:/Users/tangming/.m2/repository/org/ow2/asm/asm-debug-all/5.0.2/asm-debug-all-5.0.2.jar:/Users/tangming/.m2/repository/org/ow2/asm/asm-commons/5.0.2/asm-commons-5.0.2.jar:/Users/tangming/.m2/repository/org/ow2/asm/asm-tree/5.0.2/asm-tree-5.0.2.jar:/Users/tangming/.m2/repository/org/ow2/asm/asm/5.0.2/asm-5.0.2.jar:/Users/tangming/.m2/repository/com/apple/AppleJavaExtensions/1.4/AppleJavaExtensions-1.4.jar:/Users/tangming/.m2/repository/jaxen/jaxen/1.1.6/jaxen-1.1.6.jar" com.intellij.rt.execution.junit.JUnitStarter -ideVersion5 -junit4 com.amazon.janusgraph.TestCiHeartbeat
13:35:23.549 [main] INFO  c.a.janusgraph.testutils.CiHeartbeat - Heartbeat - [started] - testHeartbeatConsoleOutput - 0ms
13:35:24.053 [Unit test heartbeat timer] INFO  c.a.j.testutils.HeartbeatTimerTask - Heartbeat - [1] - testHeartbeatConsoleOutput - 506ms
13:35:24.558 [Unit test heartbeat timer] INFO  c.a.j.testutils.HeartbeatTimerTask - Heartbeat - [2] - testHeartbeatConsoleOutput - 1010ms
13:35:25.060 [Unit test heartbeat timer] WARN  c.a.j.testutils.HeartbeatTimerTask - Heartbeat - [3] - testHeartbeatConsoleOutput - 1512ms.
13:35:25.556 [main] INFO  c.a.janusgraph.testutils.CiHeartbeat - Heartbeat - [finished] - testHeartbeatConsoleOutput - 2009ms

```
